### PR TITLE
New error format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 *.out
+.vendor/
+output

--- a/godis_benchmark_test.go
+++ b/godis_benchmark_test.go
@@ -33,7 +33,7 @@ func BenchmarkEXISTS(b *testing.B) {
 
 	// run the EXISTS method b.N times
 	for n := 0; n < b.N; n++ {
-		_ = db.EXISTS("key")
+		_, _ = db.EXISTS("key")
 	}
 }
 

--- a/keys.go
+++ b/keys.go
@@ -32,7 +32,7 @@ func (g *Godis) RENAME(key, newKey string) (string, error) {
 	if key == newKey {
 		return "", errors.New("samekeys")
 	}
-	if got, _ := g.EXISTS(key); got== 0 {
+	if got, _ := g.EXISTS(key); got == 0 {
 		return "", errors.New("keynotexists")
 	}
 	if got, _ := g.EXISTS(newKey); got > 0 {

--- a/keys_test.go
+++ b/keys_test.go
@@ -146,10 +146,10 @@ func TestRENAMENX(t *testing.T) {
 	key := "myKey"
 	newKey := "hisKey"
 	db.SET(key, "value")
-	got, err := db.RENAMENX(key, newKey)
-	if err != nil {
-		t.Errorf("RENAMENX(%s, %s) == %s, %v want %s, <nil>", key, newKey, got,
-			err, newKey)
+	db.RENAMENX(key, newKey)
+	got, err := db.GET(newKey)
+	if got != "value" || err != nil {
+		t.Errorf("GET(%q) == %q, %v want %q, <nil>", newKey, got, err, "value")
 	}
 }
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -50,37 +50,37 @@ func TestDEL(t *testing.T) {
 
 	// DEL a key which exists
 	key := "மொழி"
-	got, _ := db.DEL(key)
+	got, err := db.DEL(key)
 	if got != 1 {
-		t.Errorf("DEL(%q) == %d, want %d", key, got, 1)
+		t.Errorf("DEL(%q) == %d, %v want %d, <nil>", key, got, err, 1)
 	}
 
 	// DEL a key which doesn't exist
 	key = "foo"
-	got, _ = db.DEL(key)
+	got, err = db.DEL(key)
 	if got != 0 {
-		t.Errorf("DEL(%q) == %d, want %d", key, got, 0)
+		t.Errorf("DEL(%q) == %d, %v want %d, <nil>", key, got, err, 0)
 	}
 
 	// DEL a list of keys which all exist
 	removeKeys := []string{"key1", "key 3"}
-	got, _ = db.DEL(removeKeys...)
+	got, err = db.DEL(removeKeys...)
 	if got != len(removeKeys) {
-		t.Errorf("DEL(%q) == %d, want %d", removeKeys, got, len(removeKeys))
+		t.Errorf("DEL(%q) == %d, %v want %d, <nil>", removeKeys, got, err, len(removeKeys))
 	}
 
 	// DEL a list of keys which has one non-existent key
 	removeKeys = []string{"key2", "not-exists"}
-	got, _ = db.DEL(removeKeys...)
+	got, err = db.DEL(removeKeys...)
 	if got != 1 {
-		t.Errorf("DEL(%q) == %d, want %d", removeKeys, got, 1)
+		t.Errorf("DEL(%q) == %d, %v want %d, <nil>", removeKeys, got, err, 1)
 	}
 
 	// DEL a list of keys which has all non-existent keys
 	removeKeys = []string{"foo", "bar", "baz"}
-	got, _ = db.DEL(removeKeys...)
+	got, err = db.DEL(removeKeys...)
 	if got != 0 {
-		t.Errorf("DEL(%q) == %d, want %d", removeKeys, got, 0)
+		t.Errorf("DEL(%q) == %d, %v, want %d, <nil>", removeKeys, got, err, 0)
 	}
 }
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -12,32 +12,32 @@ func TestEXISTS(t *testing.T) {
 
 	// one existent key
 	key := "key1"
-	if got, _ := db.EXISTS(key); got != 1 {
-		t.Errorf("EXISTS(%q) == %v, want %d", key, got, 1)
+	if got, err := db.EXISTS(key); got != 1 {
+		t.Errorf("EXISTS(%q) == %v, %v want %d, <nil>", key, got, err, 1)
 	}
 
 	// one non-existent key
 	notEXISTSKey := "not-exists"
-	if got, _ := db.EXISTS(notEXISTSKey); got != 0 {
-		t.Errorf("EXISTS(%q) == %v, want %v", notEXISTSKey, got, 0)
+	if got, err := db.EXISTS(notEXISTSKey); got != 0 {
+		t.Errorf("EXISTS(%q) == %v, %v want %v, <nil>", notEXISTSKey, got, err, 0)
 	}
 
 	// all existent keys
 	keys := []string{"key1", "key2", "key 3"}
-	if got, _ := db.EXISTS(keys...); got != len(keys) {
-		t.Errorf("EXISTS(%q) == %d, want %d", keys, got, len(keys))
+	if got, err := db.EXISTS(keys...); got != len(keys) {
+		t.Errorf("EXISTS(%q) == %d, %v want %d, <nil>", keys, got, err, len(keys))
 	}
 
 	// two existent keys and one non-existent keys
 	keys = []string{"key1", "key2", "foo"}
-	if got, _ := db.EXISTS(keys...); got != 2 {
-		t.Errorf("EXISTS(%q) == %d, want %d", keys, got, 2)
+	if got, err := db.EXISTS(keys...); got != 2 {
+		t.Errorf("EXISTS(%q) == %d, %v want %d, <nil>", keys, got, err, 2)
 	}
 
 	// all non existent keys
 	keys = []string{"foo", "bar", "baz"}
-	if got, _ := db.EXISTS(keys...); got != 0 {
-		t.Errorf("EXISTS(%q) == %d, want %d", keys, got, 0)
+	if got, err := db.EXISTS(keys...); got != 0 {
+		t.Errorf("EXISTS(%q) == %d, %v want %d, <nil>", keys, got, err, 0)
 	}
 
 }

--- a/keys_test.go
+++ b/keys_test.go
@@ -12,31 +12,31 @@ func TestEXISTS(t *testing.T) {
 
 	// one existent key
 	key := "key1"
-	if got := db.EXISTS(key); got != 1 {
+	if got, _ := db.EXISTS(key); got != 1 {
 		t.Errorf("EXISTS(%q) == %v, want %d", key, got, 1)
 	}
 
 	// one non-existent key
 	notEXISTSKey := "not-exists"
-	if got := db.EXISTS(notEXISTSKey); got != 0 {
+	if got, _ := db.EXISTS(notEXISTSKey); got != 0 {
 		t.Errorf("EXISTS(%q) == %v, want %v", notEXISTSKey, got, 0)
 	}
 
 	// all existent keys
 	keys := []string{"key1", "key2", "key 3"}
-	if got := db.EXISTS(keys...); got != len(keys) {
+	if got, _ := db.EXISTS(keys...); got != len(keys) {
 		t.Errorf("EXISTS(%q) == %d, want %d", keys, got, len(keys))
 	}
 
 	// two existent keys and one non-existent keys
 	keys = []string{"key1", "key2", "foo"}
-	if got := db.EXISTS(keys...); got != 2 {
+	if got, _ := db.EXISTS(keys...); got != 2 {
 		t.Errorf("EXISTS(%q) == %d, want %d", keys, got, 2)
 	}
 
 	// all non existent keys
 	keys = []string{"foo", "bar", "baz"}
-	if got := db.EXISTS(keys...); got != 0 {
+	if got, _ := db.EXISTS(keys...); got != 0 {
 		t.Errorf("EXISTS(%q) == %d, want %d", keys, got, 0)
 	}
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -163,7 +163,7 @@ func TestRENAMENXSameKeys(t *testing.T) {
 	// TODO : Check whether the error is returned as simple string or enclosed by
 	// error(samekeys)
 	if err.Error() != "samekeys" {
-		t.Errorf("RENAMENX(%s, %s) == %v, %v want %s, samekeys", key, newKey, got,
+		t.Errorf("RENAMENX(%q, %q) == %q, %v want %q, samekeys", key, newKey, got,
 			err, got)
 	}
 }
@@ -177,7 +177,7 @@ func TestRENAMENXNonExistant(t *testing.T) {
 	// TODO : Check whether the error is returned as simple string or enclosed by
 	// error(keynotexists)
 	if err.Error() != "keynotexists" {
-		t.Errorf("RENAMENX(%s, %s) == %s, %v want %s, keynotexists", key, newKey,
+		t.Errorf("RENAMENX(%q, %q) == %q, %v want %q, keynotexists", key, newKey,
 			got, err, got)
 	}
 }
@@ -191,7 +191,8 @@ func TestRENAMENXNewKeyExist(t *testing.T) {
 	db.SET(newKey, "somevalue")
 	got, err := db.RENAMENX(key, newKey)
 	if err.Error() != "newkeyexists" {
-		t.Errorf("RENAMENX(%s, %s) == %s, %v want %s, <nil>", key, newKey, got, err, newKey)
+		t.Errorf("RENAMENX(%q, %q) == %q, %v want %q, newkeyexists", key, newKey,
+			got, err, newKey)
 	}
 }
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -90,10 +90,10 @@ func TestRENAME(t *testing.T) {
 	key := "myKey"
 	newKey := "hisKey"
 	db.SET(key, "value")
-	got, err := db.RENAME(key, newKey)
-	if err != nil {
-		t.Errorf("RENAME(%q, %q) == %q, %v want %q, <nil>", key, newKey, got,
-			err, newKey)
+	db.RENAME(key, newKey)
+	got, err := db.GET(newKey)
+	if got != "value" || err != nil {
+		t.Errorf("GET(%q) == %q, %v want %q, <nil>", newKey, got, err, "value")
 	}
 }
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -92,7 +92,7 @@ func TestRENAME(t *testing.T) {
 	db.SET(key, "value")
 	got, err := db.RENAME(key, newKey)
 	if err != nil {
-		t.Errorf("RENAME(%s, %s) == %s, %v want %s, <nil>", key, newKey, got,
+		t.Errorf("RENAME(%q, %q) == %q, %v want %q, <nil>", key, newKey, got,
 			err, newKey)
 	}
 }
@@ -107,7 +107,7 @@ func TestRENAMESameKeys(t *testing.T) {
 	// TODO : Check whether the error is returned as simple string or enclosed by
 	// error(samekeys)
 	if err.Error() != "samekeys" {
-		t.Errorf("RENAME(%s, %s) == %v, %v want %s, samekeys", key, newKey, got,
+		t.Errorf("RENAME(%q, %q) == %q, %v want %q, samekeys", key, newKey, got,
 			err, got)
 	}
 }
@@ -121,7 +121,7 @@ func TestRENAMENonExistant(t *testing.T) {
 	// TODO : Check whether the error is returned as simple string or enclosed by
 	// error(keynotexists)
 	if err.Error() != "keynotexists" {
-		t.Errorf("RENAME(%s, %s) == %s, %v want %s, keynotexists", key, newKey,
+		t.Errorf("RENAME(%q, %q) == %q, %v want %q, keynotexists", key, newKey,
 			got, err, got)
 	}
 }
@@ -135,7 +135,7 @@ func TestRENAMENewKeyExist(t *testing.T) {
 	db.SET(newKey, "somevalue")
 	got, err := db.RENAME(key, newKey)
 	if err != nil {
-		t.Errorf("RENAME(%s, %s) == %s, %v want %s, <nil>", key, newKey, got, err, newKey)
+		t.Errorf("RENAME(%q, %q) == %q, %v want %q, <nil>", key, newKey, got, err, newKey)
 	}
 }
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -208,6 +208,8 @@ func TestRANDOMKEY(t *testing.T) {
 }
 
 // Test RANDOMKEY for non-existant db
+// TODO : RANDOMKEY should return "" instead of <nil>
+// with emptydb error
 func TestRANDOMKEYNonExistant(t *testing.T) {
 	db := setUp()
 	got, err := db.RANDOMKEY()

--- a/keys_test.go
+++ b/keys_test.go
@@ -191,8 +191,8 @@ func TestRENAMENXNewKeyExist(t *testing.T) {
 	db.SET(newKey, "somevalue")
 	got, err := db.RENAMENX(key, newKey)
 	if err.Error() != "newkeyexists" {
-		t.Errorf("RENAMENX(%q, %q) == %q, %v want %q, newkeyexists", key, newKey,
-			got, err, newKey)
+		t.Errorf("RENAMENX(%q, %q) == %q, %v want \"\", newkeyexists", key, newKey,
+			got, err)
 	}
 }
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -133,9 +133,10 @@ func TestRENAMENewKeyExist(t *testing.T) {
 	newKey := "hisKey"
 	db.SET(key, "value")
 	db.SET(newKey, "somevalue")
-	got, err := db.RENAME(key, newKey)
-	if err != nil {
-		t.Errorf("RENAME(%q, %q) == %q, %v want %q, <nil>", key, newKey, got, err, newKey)
+	db.RENAME(key, newKey)
+	got, err := db.GET(newKey)
+	if got != "value" || err != nil {
+		t.Errorf("GET(%q) == %q, %v want %q, <nil>", newKey, got, err, "value")
 	}
 }
 

--- a/keys_test.go
+++ b/keys_test.go
@@ -203,7 +203,7 @@ func TestRANDOMKEY(t *testing.T) {
 		"key5", "val5", "key6", "val6", "key7", "val7", "key8", "val8")
 	got, err := db.RANDOMKEY()
 	if err != nil {
-		t.Errorf("RANDOMKEY() == %v,%v want %v,<nil>", got, err, got)
+		t.Errorf("RANDOMKEY() == %q, %v want %q, <nil>", got, err, got)
 	}
 }
 
@@ -212,6 +212,6 @@ func TestRANDOMKEYNonExistant(t *testing.T) {
 	db := setUp()
 	got, err := db.RANDOMKEY()
 	if err.Error() != "emptydb" {
-		t.Errorf("RANDOMKEY() == %v,%v want %v,emptydb", got, err, got)
+		t.Errorf("RANDOMKEY() == %q,%v want %q,emptydb", got, err, got)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -5,6 +5,8 @@ import (
 )
 
 //DBSIZE returns the number of keys of type int64 in the currently selected database.
+// TODO : DBSIZE scans the entire database, implement an efficient logic like
+//maintaining separate db for statistics of keys.
 func (g *Godis) DBSIZE() (int64, error) {
 	return int64(len(g.db)), nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -11,6 +11,6 @@ func TestDBSIZE(t *testing.T) {
 		"5", "mykey6", "6", "mykey7", "7", "mykey8", "8", "mykey9", "9")
 	got, err := db.DBSIZE()
 	if err != nil || got != 10 {
-		t.Errorf("DBSIZE() == %v,%v want 10,<nil>", got, err)
+		t.Errorf("DBSIZE() == %v, %v want 10, <nil>", got, err)
 	}
 }

--- a/strings.go
+++ b/strings.go
@@ -33,7 +33,7 @@ func (g *Godis) GET(key string) (string, bool) {
 }
 
 // SETEX is used to assign a value to a key and destroy it within its given
-//expiry time in seconds
+//expiry time in seconds, returns the key,<nil> if set or "",<nil>
 func (g *Godis) SETEX(key string, exp uint64, value string) (string, error) {
 	if exp <= 0 {
 		return "", errors.New("badexpiry")
@@ -44,7 +44,7 @@ func (g *Godis) SETEX(key string, exp uint64, value string) (string, error) {
 }
 
 // PSETEX is used to assign a value to a key and destroy it within its given
-// expiry time in milliseconds
+// expiry time in milliseconds, returns the key,<nil> if set or "",<nil>
 func (g *Godis) PSETEX(key string, exp uint64, value string) (string, error) {
 	if exp <= 0 {
 		return "", errors.New("badexpiry")

--- a/strings.go
+++ b/strings.go
@@ -91,7 +91,7 @@ func (g *Godis) MGET(keys ...string) []interface{} {
 	var output []interface{} // will be strings or nils
 	for _, key := range keys {
 		value, err := g.GET(key)
-		if err != nil {
+		if err == nil {
 			output = append(output, value)
 		} else {
 			// if the key isn't available, append a nil instead

--- a/strings.go
+++ b/strings.go
@@ -123,7 +123,7 @@ func (g *Godis) MSET(items ...string) (bool, error) {
 //An error is returned when key holds a non-string value.
 func (g *Godis) STRLEN(key string) (int64, error) {
 	val, err := g.GET(key)
-	if err.Error() == "keynotfound" {
+	if err != nil && err.Error() == "keynotfound" {
 		return 0, errors.New("keynotfound")
 	}
 	if reflect.ValueOf(val).Kind() != reflect.String {

--- a/strings.go
+++ b/strings.go
@@ -55,34 +55,35 @@ func (g *Godis) PSETEX(key string, exp uint64, value string) (string, error) {
 }
 
 // INCR increments the key by one
-func (g *Godis) INCR(key string) (string, bool) {
+func (g *Godis) INCR(key string) (int, error) {
 	return g.INCRBY(key, 1)
 }
 
 // DECR decrements the key by one
-func (g *Godis) DECR(key string) (string, bool) {
+func (g *Godis) DECR(key string) (int, error) {
 	return g.DECRBY(key, 1)
 }
 
 // INCRBY increments the key by given value
-func (g *Godis) INCRBY(key string, n int) (string, bool) {
+func (g *Godis) INCRBY(key string, n int) (int, error) {
 	if got, _ := g.EXISTS(key); got == 0 {
 		g.SET(key, "0")
 	}
 	val, err := g.GET(key)
 	if err == nil {
 		valInt, convErr := strconv.Atoi(val)
-		if convErr == nil {
-			valInt += n
-			g.SET(key, strconv.Itoa(valInt))
-			return strconv.Itoa(valInt), false
+		if convErr != nil {
+			return 0, errors.New("typemismatch")
 		}
+		valInt += n
+		g.SET(key, strconv.Itoa(valInt))
+		return valInt, nil
 	}
-	return "", true
+	return 0, errors.New("keynotexists")
 }
 
 // DECRBY decrements the key by given value
-func (g *Godis) DECRBY(key string, n int) (string, bool) {
+func (g *Godis) DECRBY(key string, n int) (int, error) {
 	return g.INCRBY(key, -n)
 }
 

--- a/strings.go
+++ b/strings.go
@@ -88,7 +88,7 @@ func (g *Godis) DECRBY(key string, n int) (int, error) {
 }
 
 // MGET returns a slice of values for a input slice of keys
-func (g *Godis) MGET(keys ...string) []interface{} {
+func (g *Godis) MGET(keys ...string) ([]interface{}, error) {
 	var output []interface{} // will be strings or nils
 	for _, key := range keys {
 		value, err := g.GET(key)
@@ -100,13 +100,14 @@ func (g *Godis) MGET(keys ...string) []interface{} {
 			output = append(output, nil)
 		}
 	}
-	return output
+	return output, nil
 }
 
 // MSET sets a slice of key-values
 // pass a slice of keys and value alternating
 // eg: "key1", "value1", "key2", "value2"
-func (g *Godis) MSET(items ...string) bool {
+// returns true, <nil> as MSET never fails!
+func (g *Godis) MSET(items ...string) (bool, error) {
 	g.Lock()
 	defer g.Unlock()
 	for i, item := range items {
@@ -115,7 +116,7 @@ func (g *Godis) MSET(items ...string) bool {
 		}
 		g.SET(item, items[i+1])
 	}
-	return true
+	return true, nil
 }
 
 //STRLEN returns the length of the string value stored at key.

--- a/strings.go
+++ b/strings.go
@@ -36,7 +36,7 @@ func (g *Godis) GET(key string) (string, bool) {
 //expiry time in seconds
 func (g *Godis) SETEX(key string, exp uint64, value string) (string, error) {
 	if exp <= 0 {
-		return "", errors.New("invalid expire time in SETEX")
+		return "", errors.New("badexpiry")
 	}
 	g.SET(key, value)
 	go g.destroyInSecs(key, exp)
@@ -47,7 +47,7 @@ func (g *Godis) SETEX(key string, exp uint64, value string) (string, error) {
 // expiry time in milliseconds
 func (g *Godis) PSETEX(key string, exp uint64, value string) (string, error) {
 	if exp <= 0 {
-		return "", errors.New("invalid expire time in PSETEX")
+		return "", errors.New("badexpiry")
 	}
 	g.SET(key, value)
 	go g.destroyInMillis(key, exp)

--- a/strings.go
+++ b/strings.go
@@ -123,8 +123,8 @@ func (g *Godis) MSET(items ...string) (bool, error) {
 //An error is returned when key holds a non-string value.
 func (g *Godis) STRLEN(key string) (int64, error) {
 	val, err := g.GET(key)
-	if err != nil && err.Error() == "keynotfound" {
-		return 0, errors.New("keynotfound")
+	if err != nil && err.Error() == "keynotexists" {
+		return 0, errors.New("keynotexists")
 	}
 	if reflect.ValueOf(val).Kind() != reflect.String {
 		return 0, errors.New("typemismatch")

--- a/strings.go
+++ b/strings.go
@@ -79,7 +79,6 @@ func (g *Godis) INCRBY(key string, n int) (int, error) {
 		g.SET(key, strconv.Itoa(valInt))
 		return valInt, nil
 	}
-	return 0, errors.New("keynotexists")
 }
 
 // DECRBY decrements the key by given value

--- a/strings.go
+++ b/strings.go
@@ -66,19 +66,20 @@ func (g *Godis) DECR(key string) (int, error) {
 
 // INCRBY increments the key by given value
 func (g *Godis) INCRBY(key string, n int) (int, error) {
-	if got, _ := g.EXISTS(key); got == 0 {
+	var val string
+	var err error
+	val, err = g.GET(key)
+	if val == "" || err != nil {
 		g.SET(key, "0")
+		val, _ = g.GET(key)
 	}
-	val, err := g.GET(key)
-	if err == nil {
-		valInt, convErr := strconv.Atoi(val)
-		if convErr != nil {
-			return 0, errors.New("typemismatch")
-		}
-		valInt += n
-		g.SET(key, strconv.Itoa(valInt))
-		return valInt, nil
+	valInt, convErr := strconv.Atoi(val)
+	if convErr != nil {
+		return 0, errors.New("typemismatch")
 	}
+	valInt += n
+	g.SET(key, strconv.Itoa(valInt))
+	return valInt, nil
 }
 
 // DECRBY decrements the key by given value

--- a/strings.go
+++ b/strings.go
@@ -24,12 +24,12 @@ func (g *Godis) SET(key string, value string) (string, error) {
 }
 
 // GET returns the value stored for a key
-func (g *Godis) GET(key string) (string, bool) {
+func (g *Godis) GET(key string) (string, error) {
 	s, exists := g.getSDS(key)
 	if exists {
-		return s.get(), false
+		return s.get(), nil
 	}
-	return "", true
+	return "", errors.New("keynotexists")
 }
 
 // SETEX is used to assign a value to a key and destroy it within its given

--- a/strings.go
+++ b/strings.go
@@ -70,7 +70,7 @@ func (g *Godis) INCRBY(key string, n int) (string, bool) {
 		g.SET(key, "0")
 	}
 	val, err := g.GET(key)
-	if !err {
+	if err == nil {
 		valInt, convErr := strconv.Atoi(val)
 		if convErr == nil {
 			valInt += n
@@ -91,7 +91,7 @@ func (g *Godis) MGET(keys ...string) []interface{} {
 	var output []interface{} // will be strings or nils
 	for _, key := range keys {
 		value, err := g.GET(key)
-		if !err {
+		if err != nil {
 			output = append(output, value)
 		} else {
 			// if the key isn't available, append a nil instead
@@ -121,7 +121,7 @@ func (g *Godis) MSET(items ...string) bool {
 //An error is returned when key holds a non-string value.
 func (g *Godis) STRLEN(key string) (int64, error) {
 	val, err := g.GET(key)
-	if err {
+	if err.Error() == "keynotfound" {
 		return 0, errors.New("keynotfound")
 	}
 	if reflect.ValueOf(val).Kind() != reflect.String {

--- a/strings_test.go
+++ b/strings_test.go
@@ -134,7 +134,7 @@ func TestDECR(t *testing.T) {
 		want, _ := strconv.Atoi(c.value)
 		want -= 1
 		if got != want {
-			t.Errorf("DECR(%q) == %s, %v want %s, <nil>", c.key, got, err, want)
+			t.Errorf("DECR(%q) == %d, %v want %d, <nil>", c.key, got, err, want)
 		}
 	}
 }
@@ -159,7 +159,7 @@ func TestINCRBY(t *testing.T) {
 		want, _ := strconv.Atoi(c.value)
 		want += n
 		if got != want {
-			t.Errorf("INCRBY(%q) == %s, %v want %s, <nil>", c.key, got, err, want)
+			t.Errorf("INCRBY(%q) == %d, %v want %d, <nil>", c.key, got, err, want)
 		}
 	}
 }
@@ -230,7 +230,7 @@ func TestSETEXWithinExp(t *testing.T) {
 	time.Sleep(time.Duration(exp-1) * time.Second)
 	res, _ := db.EXISTS(key)
 	if res != 1 {
-		t.Errorf("SETEX(%q, %d, %v) == %d, <nil> want %d, <nil>", key, exp, val, got, 1)
+		t.Errorf("SETEX(%q, %d, %v) == %s, <nil> want %s, <nil>", key, exp, val, got, key)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -120,8 +120,8 @@ func TestINCRNonExists(t *testing.T) {
 	db := setUp()
 	key := "non-incr-key"
 	got, err := db.INCR(key)
-	if err.Error() != "keynotexists" {
-		t.Errorf("INCR(%q) == %s, %v want %d, keynotexists", key, got, err, 0)
+	if got != 1 {
+		t.Errorf("INCR(%q) == %d, %v want %d, <nil>", key, got, err, 1)
 	}
 }
 
@@ -144,8 +144,8 @@ func TestDECRNonExists(t *testing.T) {
 	db := setUp()
 	key := "non-incr-key"
 	got, err := db.DECR(key)
-	if err.Error() != "keynotexists" {
-		t.Errorf("DECR(%q) == %s, %v want %d, keynotexists", key, got, err, 0)
+	if got != -1 {
+		t.Errorf("DECR(%q) == %d, %v want %d, <nil>", key, got, err, -1)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -294,9 +294,9 @@ func TestPSETEXWithZero(t *testing.T) {
 	val := "some value"
 	exp := 0
 	db := setUp()
-	_, err := db.PSETEX(key, uint64(exp), val)
+	got, err := db.PSETEX(key, uint64(exp), val)
 	if err == nil {
-		t.Errorf("PSETEX(%q, %d) == nil, want Error(\"invalid expire time in PSETEX\")", key, exp)
+		t.Errorf("PSETEX(%q, %d, %q) == %q, %v want \"\", badexpiry", key, exp, val, got, err)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -110,7 +110,7 @@ func TestINCR(t *testing.T) {
 		want, _ := strconv.Atoi(c.value)
 		want += 1
 		if got != want {
-			t.Errorf("INCR(%q) == %s, %v want %s, <nil>", c.key, got, err, want)
+			t.Errorf("INCR(%q) == %d, %v want %d, <nil>", c.key, got, err, want)
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -66,8 +66,8 @@ func TestMGETNotExists(t *testing.T) {
 	}
 	got, err := db.MGET(testKeys...)
 	for i, key := range testKeys {
-		if got[i] != nil && err != nil {
-			t.Errorf("MGET(%q) == %q, want %p", key, got[i], nil)
+		if got[i] != nil || err != nil {
+			t.Errorf("MGET(%q) == %v, %v want %v, <nil>", key, got[i], err, nil)
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -106,11 +106,11 @@ func TestINCR(t *testing.T) {
 	db := setUp()
 	for _, c := range integers {
 		db.SET(c.key, c.value)
-		got, _ := db.INCR(c.key)
+		got, err := db.INCR(c.key)
 		want, _ := strconv.Atoi(c.value)
-		wantStr := want + 1
-		if got != wantStr {
-			t.Errorf("INCR(%q) == %s, want %s", c.key, got, wantStr)
+		want += 1
+		if got != want {
+			t.Errorf("INCR(%q) == %s, %v want %s, <nil>", c.key, got, err, want)
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -242,9 +242,9 @@ func TestSETEXAfterExp(t *testing.T) {
 	db := setUp()
 	db.SETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp+1) * time.Second)
-	got, _ := db.EXISTS(key)
-	if got != 0 {
-		t.Errorf("SETEX(%q, %d) == %d, want %d", key, exp, got, 0)
+	got, err := db.GET(key)
+	if got != "" || err.Error() != "keynotexists" {
+		t.Errorf("GET(%q) == %q, %v want \"\", keynotexists", key, got, err)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -170,9 +170,9 @@ func TestINCRBYString(t *testing.T) {
 	n := 3
 	key := "foo"
 	db.SET(key, "string value")
-	_, err := db.INCRBY(key, n)
-	if !err {
-		t.Errorf("INCRBY(%q, %d) == %t, want %t", key, n, err, true)
+	got, err := db.INCRBY(key, n)
+	if err.Error() != "typemismatch" {
+		t.Errorf("INCRBY(%q, %d) == %d, %v want 0, typemismatch", key, n, got, err)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -37,7 +37,7 @@ func TestGETNotEXISTS(t *testing.T) {
 	got, err := db.GET(key)
 	if err.Error() != "keynotexists" {
 		// Means the key exists
-		t.Errorf("GET(%q) == %s, %v want %s, keynotexists", key, got, err, "")
+		t.Errorf("GET(%q) == %q, %v want %q, keynotexists", key, got, err, "")
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -130,11 +130,11 @@ func TestDECR(t *testing.T) {
 	db := setUp()
 	for _, c := range integers {
 		db.SET(c.key, c.value)
-		got, _ := db.DECR(c.key)
+		got, err := db.DECR(c.key)
 		want, _ := strconv.Atoi(c.value)
 		want -= 1
-		if got != wantStr {
-			t.Errorf("DECR(%q) == %s, want %s", c.key, got, wantStr)
+		if got != want {
+			t.Errorf("DECR(%q) == %s, %v want %s, <nil>", c.key, got, err, want)
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -197,9 +197,9 @@ func TestDECRBYString(t *testing.T) {
 	n := 3
 	key := "foo"
 	db.SET(key, "string value")
-	_, err := db.DECRBY(key, n)
-	if !err {
-		t.Errorf("DECRBY(%q, %d) == %t, want %t", key, n, err, true)
+	got, err := db.DECRBY(key, n)
+	if err.Error() != "typemismatch" {
+		t.Errorf("DECRBY(%q, %d) == %d, %v want 0, typemismatch", key, n, got, err)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -132,7 +132,7 @@ func TestDECR(t *testing.T) {
 		db.SET(c.key, c.value)
 		got, _ := db.DECR(c.key)
 		want, _ := strconv.Atoi(c.value)
-		wantStr := strconv.Itoa(want - 1)
+		want -= 1
 		if got != wantStr {
 			t.Errorf("DECR(%q) == %s, want %s", c.key, got, wantStr)
 		}

--- a/strings_test.go
+++ b/strings_test.go
@@ -224,11 +224,11 @@ func TestSETEXWithinExp(t *testing.T) {
 	val := "some value"
 	exp := 2
 	db := setUp()
-	db.SETEX(key, uint64(exp), val)
+	got, err := db.SETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp-1) * time.Second)
-	got, _ := db.EXISTS(key)
-	if got != 1 {
-		t.Errorf("SETEX(%q, %d) == %d, want %d", key, exp, got, 1)
+	res, _ := db.EXISTS(key)
+	if res != 1 {
+		t.Errorf("SETEX(%q, %d, %v) == %d, <nil> want %d, <nil>", key, exp, val, got, 1)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -51,8 +51,8 @@ func TestMGET(t *testing.T) {
 	}
 	got, err := db.MGET(testKeys...)
 	for i, key := range testKeys {
-		if got[i] != want[i] && err != nil {
-			t.Errorf("MGET(%q) == %q, want %q", key, got[i], want[i])
+		if got[i] != want[i] || err != nil {
+			t.Errorf("MGET(%q) == %q, %v want %q, <nil>", key, got[i], err, want[i])
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -365,7 +365,7 @@ func TestSTRLENWithoutKey(t *testing.T) {
 	db := setUp()
 	key := "mykey"
 	got, err := db.STRLEN(key)
-	if err.Error() != "keynotfound" {
+	if err != nil && err.Error() != "keynotfound" {
 		t.Errorf("STRLEN(%q) == %v,%v want 0,keynotfound", key, got, err)
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -51,7 +51,7 @@ func TestMGET(t *testing.T) {
 	}
 	got, err := db.MGET(testKeys...)
 	for i, key := range testKeys {
-		if got[i] != want[i] {
+		if got[i] != want[i] && err != nil {
 			t.Errorf("MGET(%q) == %q, want %q", key, got[i], want[i])
 		}
 	}
@@ -64,9 +64,9 @@ func TestMGETNotExists(t *testing.T) {
 	for _, c := range cases {
 		db.SET(c.key, c.value)
 	}
-	got := db.MGET(testKeys...)
+	got, err := db.MGET(testKeys...)
 	for i, key := range testKeys {
-		if got[i] != nil {
+		if got[i] != nil && err != nil {
 			t.Errorf("MGET(%q) == %q, want %p", key, got[i], nil)
 		}
 	}
@@ -80,12 +80,12 @@ func TestMGETFewNotExists(t *testing.T) {
 	for _, c := range cases {
 		db.SET(c.key, c.value)
 	}
-	got := db.MGET(testKeys...)
+	got, err := db.MGET(testKeys...)
 	for i, key := range testKeys {
-		if i == 1 && got[i] != nil {
+		if i == 1 && got[i] != nil && err != nil {
 			t.Errorf("MGET(%q) == %q, want %p", key, got[i], nil)
 		}
-		if i != 1 && got[i] != want[i] {
+		if i != 1 && got[i] != want[i] && err != nil {
 			t.Errorf("MGET(%q) == %q, want %q", key, got[i], want[i])
 		}
 	}

--- a/strings_test.go
+++ b/strings_test.go
@@ -226,11 +226,11 @@ func TestSETEXWithinExp(t *testing.T) {
 	val := "some value"
 	exp := 2
 	db := setUp()
-	got, _ := db.SETEX(key, uint64(exp), val)
+	got, err := db.SETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp-1) * time.Second)
 	res, _ := db.EXISTS(key)
-	if res != 1 {
-		t.Errorf("SETEX(%q, %d, %v) == %s, <nil> want %s, <nil>", key, exp, val, got, key)
+	if res != 1 || err != nil {
+		t.Errorf("SETEX(%q, %d, %v) == %s, %v want %s, <nil>", key, exp, val, got, err, key)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -365,7 +365,7 @@ func TestSTRLENWithoutKey(t *testing.T) {
 	db := setUp()
 	key := "mykey"
 	got, err := db.STRLEN(key)
-	if err != nil && err.Error() != "keynotfound" {
+	if err.Error() != "keynotfound" {
 		t.Errorf("STRLEN(%q) == %v,%v want 0,keynotfound", key, got, err)
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -155,11 +155,11 @@ func TestINCRBY(t *testing.T) {
 	n := 3
 	for _, c := range integers {
 		db.SET(c.key, c.value)
-		got, _ := db.INCRBY(c.key, n)
+		got, err := db.INCRBY(c.key, n)
 		want, _ := strconv.Atoi(c.value)
-		wantStr := strconv.Itoa(want + n)
-		if got != wantStr {
-			t.Errorf("INCRBY(%q) == %s, want %s", c.key, got, wantStr)
+		want += n
+		if got != want {
+			t.Errorf("INCRBY(%q) == %s, %v want %s, <nil>", c.key, got, err, want)
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -12,7 +12,7 @@ func TestSET(t *testing.T) {
 	db := setUp()
 	for _, c := range cases {
 		got, err := db.SET(c.key, c.value)
-		if got != c.key || err == nil {
+		if got != c.key || err != nil {
 			t.Errorf("SET(%q, %v) == %q, %v want %q, <nil>", c.key, c.value, got, err, c.key)
 		}
 	}
@@ -24,7 +24,7 @@ func TestGET(t *testing.T) {
 	for _, c := range cases {
 		db.SET(c.key, c.value)
 		got, err := db.GET(c.key)
-		if err != nil && got != c.value {
+		if err != nil || got != c.value {
 			t.Errorf("GET(%q) == %q, %v want %q, <nil>", c.key, got, err, c.value)
 		}
 	}

--- a/strings_test.go
+++ b/strings_test.go
@@ -254,9 +254,9 @@ func TestSETEXWithZero(t *testing.T) {
 	val := "some value"
 	exp := 0
 	db := setUp()
-	_, err := db.SETEX(key, uint64(exp), val)
+	got, err := db.SETEX(key, uint64(exp), val)
 	if err == nil {
-		t.Errorf("SETEX(%q, %d) == nil, want Error(\"invalid expire time in SETEX\")", key, exp)
+		t.Errorf("SETEX(%q, %d, %q) == %q, %v want \"\", badexpiry", key, exp, val, got, err)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -96,7 +96,7 @@ func TestMSET(t *testing.T) {
 	tests := []string{"key1", "value1", "key2", "value2", "key3", "value3"}
 	db := setUp()
 	got, err := db.MSET(tests...)
-	if got != true && err != nil {
+	if got != true || err != nil {
 		t.Errorf("MSET(%q) == %t, %v want %t, <nil>", tests, got, err, true)
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -49,7 +49,7 @@ func TestMGET(t *testing.T) {
 	for _, c := range cases {
 		db.SET(c.key, c.value)
 	}
-	got := db.MGET(testKeys...)
+	got, err := db.MGET(testKeys...)
 	for i, key := range testKeys {
 		if got[i] != want[i] {
 			t.Errorf("MGET(%q) == %q, want %q", key, got[i], want[i])
@@ -95,9 +95,9 @@ func TestMGETFewNotExists(t *testing.T) {
 func TestMSET(t *testing.T) {
 	tests := []string{"key1", "value1", "key2", "value2", "key3", "value3"}
 	db := setUp()
-	got := db.MSET(tests...)
-	if got != true {
-		t.Errorf("MSET(%q) == %t, want %t", tests, got, true)
+	got, err := db.MSET(tests...)
+	if got != true && err != nil {
+		t.Errorf("MSET(%q) == %t, %v want %t, <nil>", tests, got, err, true)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -226,11 +226,11 @@ func TestSETEXWithinExp(t *testing.T) {
 	val := "some value"
 	exp := 2
 	db := setUp()
-	got, err := db.SETEX(key, uint64(exp), val)
+	db.SETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp-1) * time.Second)
-	res, _ := db.EXISTS(key)
-	if res != 1 || err != nil {
-		t.Errorf("SETEX(%q, %d, %v) == %s, %v want %s, <nil>", key, exp, val, got, err, key)
+	got, err := db.GET(key)
+	if got != val || err != nil {
+		t.Errorf("GET(%q) == %q, %v want %q, <nil>", key, got, err, val)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -182,11 +182,11 @@ func TestDECRBY(t *testing.T) {
 	n := 3
 	for _, c := range integers {
 		db.SET(c.key, c.value)
-		got, _ := db.DECRBY(c.key, n)
+		got, err := db.DECRBY(c.key, n)
 		want, _ := strconv.Atoi(c.value)
-		wantStr := strconv.Itoa(want - n)
-		if got != wantStr {
-			t.Errorf("DECRBY(%q) == %s, want %s", c.key, got, wantStr)
+		want -= n
+		if got != want {
+			t.Errorf("DECRBY(%q) == %d, %v want %d, <nil>", c.key, got, err, want)
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -82,11 +82,11 @@ func TestMGETFewNotExists(t *testing.T) {
 	}
 	got, err := db.MGET(testKeys...)
 	for i, key := range testKeys {
-		if i == 1 && got[i] != nil && err != nil {
-			t.Errorf("MGET(%q) == %q, want %p", key, got[i], nil)
+		if i == 1 && got[i] != nil {
+			t.Errorf("MGET(%q) == %q, %v want %p, <nil>", key, got[i], err, nil)
 		}
-		if i != 1 && got[i] != want[i] && err != nil {
-			t.Errorf("MGET(%q) == %q, want %q", key, got[i], want[i])
+		if i != 1 && got[i] != want[i] {
+			t.Errorf("MGET(%q) == %q, %v want %q, <nil>", key, got[i], err, want[i])
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -268,9 +268,9 @@ func TestPSETEXWithinExp(t *testing.T) {
 	db := setUp()
 	db.PSETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp-10) * time.Millisecond)
-	got, _ := db.EXISTS(key)
-	if got != 1 {
-		t.Errorf("PSETEX(%q, %d) == %d, want %d", key, exp, got, 1)
+	got, err := db.GET(key)
+	if got != val || err != nil {
+		t.Errorf("GET(%q) == %q, %v want %q, <nil>", key, got, err, val)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -226,7 +226,7 @@ func TestSETEXWithinExp(t *testing.T) {
 	db := setUp()
 	db.SETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp-1) * time.Second)
-	got := db.EXISTS(key)
+	got, _ := db.EXISTS(key)
 	if got != 1 {
 		t.Errorf("SETEX(%q, %d) == %d, want %d", key, exp, got, 1)
 	}
@@ -240,7 +240,7 @@ func TestSETEXAfterExp(t *testing.T) {
 	db := setUp()
 	db.SETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp+1) * time.Second)
-	got := db.EXISTS(key)
+	got, _ := db.EXISTS(key)
 	if got != 0 {
 		t.Errorf("SETEX(%q, %d) == %d, want %d", key, exp, got, 0)
 	}
@@ -266,7 +266,7 @@ func TestPSETEXWithinExp(t *testing.T) {
 	db := setUp()
 	db.PSETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp-10) * time.Millisecond)
-	got := db.EXISTS(key)
+	got, _ := db.EXISTS(key)
 	if got != 1 {
 		t.Errorf("PSETEX(%q, %d) == %d, want %d", key, exp, got, 1)
 	}
@@ -280,7 +280,7 @@ func TestPSETEXAfterExp(t *testing.T) {
 	db := setUp()
 	db.PSETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp+10) * time.Millisecond)
-	got := db.EXISTS(key)
+	got, _ := db.EXISTS(key)
 	if got != 0 {
 		t.Errorf("PSETEX(%q) == %d, want %d", key, got, 0)
 	}

--- a/strings_test.go
+++ b/strings_test.go
@@ -308,7 +308,7 @@ func TestSTRLENWithInt(t *testing.T) {
 	db.SET(key, val)
 	got, err := db.STRLEN(key)
 	if err != nil || got != 5 {
-		t.Errorf("STRLEN(%q) == %d, want %d", key, got, 5)
+		t.Errorf("STRLEN(%q) == %d, %v want %d, <nil>", key, got, err, 5)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -142,9 +142,10 @@ func TestDECR(t *testing.T) {
 // Test decrementing non-existent keys
 func TestDECRNonExists(t *testing.T) {
 	db := setUp()
-	got, _ := db.DECR("non-decr-key")
-	if got != "-1" {
-		t.Errorf("DECR(%q) == %s, want %s", "non-decr-key", got, "-1")
+	key := "non-incr-key"
+	got, err := db.DECR(key)
+	if err.Error() != "keynotexists" {
+		t.Errorf("DECR(%q) == %s, %v want %d, keynotexists", key, got, err, 0)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -118,9 +118,10 @@ func TestINCR(t *testing.T) {
 // Test incrementing non-existent keys
 func TestINCRNonExists(t *testing.T) {
 	db := setUp()
-	got, _ := db.INCR("non-incr-key")
-	if got != "1" {
-		t.Errorf("INCR(%q) == %s, want %s", "non-incr-key", got, "1")
+	key := "non-incr-key"
+	got, err := db.INCR(key)
+	if err.Error() != "keynotexists" {
+		t.Errorf("INCR(%q) == %s, %v want %d, keynotexists", key, got, err, 0)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -108,7 +108,7 @@ func TestINCR(t *testing.T) {
 		db.SET(c.key, c.value)
 		got, _ := db.INCR(c.key)
 		want, _ := strconv.Atoi(c.value)
-		wantStr := strconv.Itoa(want + 1)
+		wantStr := want + 1
 		if got != wantStr {
 			t.Errorf("INCR(%q) == %s, want %s", c.key, got, wantStr)
 		}

--- a/strings_test.go
+++ b/strings_test.go
@@ -24,8 +24,8 @@ func TestGET(t *testing.T) {
 	for _, c := range cases {
 		db.SET(c.key, c.value)
 		got, err := db.GET(c.key)
-		if !err && got != c.value {
-			t.Errorf("GET(%q) == %q, want %q", c.key, got, c.value)
+		if err != nil && got != c.value {
+			t.Errorf("GET(%q) == %q, %v want %q, <nil>", c.key, got, err, c.value)
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -12,8 +12,8 @@ func TestSET(t *testing.T) {
 	db := setUp()
 	for _, c := range cases {
 		got, err := db.SET(c.key, c.value)
-		if got != c.key || err != nil {
-			t.Errorf("SET(%q) == %q, want %q", c.key, got, c.key)
+		if got != c.key || err == nil {
+			t.Errorf("SET(%q, %v) == %q, %v want %q, <nil>", c.key, c.value, got, err, c.key)
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -34,10 +34,10 @@ func TestGET(t *testing.T) {
 func TestGETNotEXISTS(t *testing.T) {
 	db := setUp()
 	key := "not exists"
-	_, err := db.GET(key)
-	if !err {
+	got, err := db.GET(key)
+	if err.Error() != "keynotexists" {
 		// Means the key exists
-		t.Errorf("GET(%q) == %t, want %t", key, false, true)
+		t.Errorf("GET(%q) == %s, %v want %s, keynotexists", key, got, err, "")
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -282,9 +282,9 @@ func TestPSETEXAfterExp(t *testing.T) {
 	db := setUp()
 	db.PSETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp+10) * time.Millisecond)
-	got, _ := db.EXISTS(key)
-	if got != 0 {
-		t.Errorf("PSETEX(%q) == %d, want %d", key, got, 0)
+	got, err := db.GET(key)
+	if got != "" || err.Error() != "keynotexists" {
+		t.Errorf("GET(%q) == %q, %v want \"\", keynotexists", key, got, err)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -320,7 +320,7 @@ func TestSTRLENWithFloat(t *testing.T) {
 	db.SET(key, val)
 	got, err := db.STRLEN(key)
 	if err != nil || got != 11 {
-		t.Errorf("STRLEN(%q) == %d, want %d", key, got, 11)
+		t.Errorf("STRLEN(%q) == %d, %v want %d, <nil>", key, got, err, 11)
 	}
 }
 
@@ -332,7 +332,7 @@ func TestSTRLENWithLong(t *testing.T) {
 	db.SET(key, val)
 	got, err := db.STRLEN(key)
 	if err != nil || got != 43 {
-		t.Errorf("STRLEN(%q) == %d, want %d", key, got, 43)
+		t.Errorf("STRLEN(%q) == %d, %v want %d, <nil>", key, got, err, 43)
 	}
 }
 
@@ -344,7 +344,7 @@ func TestSTRLENWithStr(t *testing.T) {
 	db.SET(key, val)
 	got, err := db.STRLEN(key)
 	if err != nil || got != 58 {
-		t.Errorf("STRLEN(%q) == %d, want %d", key, got, 58)
+		t.Errorf("STRLEN(%q) == %d, %v want %d, <nil>", key, got, err, 58)
 	}
 }
 
@@ -356,7 +356,7 @@ func TestSTRLENWithoutVal(t *testing.T) {
 	db.SET(key, val)
 	got, err := db.STRLEN(key)
 	if err != nil || got != 0 {
-		t.Errorf("STRLEN(%q) == %d, want %d", key, got, 0)
+		t.Errorf("STRLEN(%q) == %d, %v want %d, <nil>", key, got, err, 0)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -224,7 +224,7 @@ func TestSETEXWithinExp(t *testing.T) {
 	val := "some value"
 	exp := 2
 	db := setUp()
-	got, err := db.SETEX(key, uint64(exp), val)
+	got, _ := db.SETEX(key, uint64(exp), val)
 	time.Sleep(time.Duration(exp-1) * time.Second)
 	res, _ := db.EXISTS(key)
 	if res != 1 {

--- a/strings_test.go
+++ b/strings_test.go
@@ -365,8 +365,8 @@ func TestSTRLENWithoutKey(t *testing.T) {
 	db := setUp()
 	key := "mykey"
 	got, err := db.STRLEN(key)
-	if err.Error() != "keynotfound" {
-		t.Errorf("STRLEN(%q) == %v,%v want 0,keynotfound", key, got, err)
+	if err.Error() != "keynotexists" {
+		t.Errorf("STRLEN(%q) == %v,%v want 0,keynotexists", key, got, err)
 	}
 }
 


### PR DESCRIPTION
Have assigned strings as error messages so that the user can compare the 
errors thrown by a command and take decisions based on that. For example if we take RENAME command, before we use to check,

```go
key = mykey
newKey = mykey
got, err := RENAME(key, newKey)
if err != nil {
 // Decide something without knowing exact error
}
```
Now we can check for exact errors,

```go
key = mykey
newKey = mykey
got, err := RENAME(key, newKey)
if err.Error() == "samekeys" {
 // Decide exactly based on error thrown
}
```
