### PR TITLE
INCRBYFLOAT

### DIFF
--- a/godis_test.go
+++ b/godis_test.go
@@ -28,10 +28,11 @@ var integers = []Case{
 	{"zero", "0"},
 }
 
-// var floats = []Case{
-// 	{"float64", 22423234.1223},
-// 	{"float", 443.21},
-// }
+var floats = []Case{
+	{"flt64", "22423234.1223"},
+	{"flt32", "443.21"},
+	{"fltExp", "123.34e23"},
+}
 
 // var strings = []Case{
 // 	{"மொழி", "தமிழ்"}, // value with string

--- a/godis_test.go
+++ b/godis_test.go
@@ -32,6 +32,8 @@ var floats = []Case{
 	{"flt64", "22423234.1223"},
 	{"flt32", "443.21"},
 	{"fltExp", "123.34e23"},
+	{"negative", "-123.34e23"},
+	{"zero", "0"},
 }
 
 // var strings = []Case{

--- a/strings.go
+++ b/strings.go
@@ -87,6 +87,26 @@ func (g *Godis) DECRBY(key string, n int) (int, error) {
 	return g.INCRBY(key, -n)
 }
 
+// Increment the string representing a floating point number stored at key by the
+//specified increment. If the key does not exist, it is set to 0 before
+//performing the operation.
+func (g *Godis) INCRBYFLOAT(key string, n float64) (float64, error) {
+	var val string
+	var err error
+	val, err = g.GET(key)
+	if val == "" || err != nil {
+		g.SET(key, "0")
+		val, _ = g.GET(key)
+	}
+	valFlt, convErr := strconv.ParseFloat(val, 64)
+	if convErr != nil {
+		return 0, errors.New("typemismatch")
+	}
+	valFlt += n
+	g.SET(key, strconv.FormatFloat(valFlt, 'E', -1, 64))
+	return valFlt, nil
+}
+
 // MGET returns a slice of values for a input slice of keys
 func (g *Godis) MGET(keys ...string) ([]interface{}, error) {
 	var output []interface{} // will be strings or nils

--- a/strings_test.go
+++ b/strings_test.go
@@ -230,7 +230,8 @@ func TestINCRBYFLOAT(t *testing.T) {
 		want, _ := strconv.ParseFloat(c.value, 64)
 		want += n
 		if got != want {
-			t.Errorf("INCRBYFLOAT(%q, %f) == %f, %v want %f, <nil>", c.key, n, got, err, want)
+			t.Errorf("INCRBYFLOAT(%q, %f) == %f, %v want %f, <nil>", c.key, n,
+				got, err, want)
 		}
 	}
 }
@@ -243,7 +244,20 @@ func TestINCRBYFLOATString(t *testing.T) {
 	db.SET(key, "string value")
 	got, err := db.INCRBYFLOAT(key, n)
 	if err.Error() != "typemismatch" {
-		t.Errorf("INCRBYFLOAT(%q, %f) == %f, %v want 0, typemismatch", key, n, got, err)
+		t.Errorf("INCRBYFLOAT(%q, %f) == %f, %v want 0, typemismatch",
+			key, n, got, err)
+	}
+}
+
+// Test incrementing values for given key by n for non existing key
+func TestINCRBYFLOATNonExists(t *testing.T) {
+	db := setUp()
+	key := "mykey"
+	n := 3.40e43
+	got, err := db.INCRBYFLOAT(key, n)
+	if got != n {
+		t.Errorf("INCRBYFLOAT(%q, %e) == %e, %v want %e, <nil>", key, n, got,
+			err, n)
 	}
 }
 

--- a/strings_test.go
+++ b/strings_test.go
@@ -220,6 +220,21 @@ func TestINCRmismatchs(t *testing.T) {
     }
 }*/
 
+// Test incrementing values for given key by n
+func TestINCRBYFLOAT(t *testing.T) {
+	db := setUp()
+	n := 3.40002154
+	for _, c := range floats {
+		db.SET(c.key, c.value)
+		got, err := db.INCRBYFLOAT(c.key, n)
+		want, _ := strconv.ParseFloat(c.value, 64)
+		want += n
+		if got != want {
+			t.Errorf("INCRBY(%q) == %d, %v want %d, <nil>", c.key, got, err, want)
+		}
+	}
+}
+
 func TestSETEXWithinExp(t *testing.T) {
 	// One second before expiry time
 	key := "mykey"

--- a/strings_test.go
+++ b/strings_test.go
@@ -159,7 +159,7 @@ func TestINCRBY(t *testing.T) {
 		want, _ := strconv.Atoi(c.value)
 		want += n
 		if got != want {
-			t.Errorf("INCRBY(%q) == %d, %v want %d, <nil>", c.key, got, err, want)
+			t.Errorf("INCRBY(%q, %d) == %d, %v want %d, <nil>", c.key, n, got, err, want)
 		}
 	}
 }
@@ -186,7 +186,7 @@ func TestDECRBY(t *testing.T) {
 		want, _ := strconv.Atoi(c.value)
 		want -= n
 		if got != want {
-			t.Errorf("DECRBY(%q) == %d, %v want %d, <nil>", c.key, got, err, want)
+			t.Errorf("DECRBY(%q, %d) == %d, %v want %d, <nil>", c.key, n, got, err, want)
 		}
 	}
 }
@@ -230,7 +230,7 @@ func TestINCRBYFLOAT(t *testing.T) {
 		want, _ := strconv.ParseFloat(c.value, 64)
 		want += n
 		if got != want {
-			t.Errorf("INCRBY(%q) == %d, %v want %d, <nil>", c.key, got, err, want)
+			t.Errorf("INCRBYFLOAT(%q, %f) == %f, %v want %f, <nil>", c.key, n, got, err, want)
 		}
 	}
 }

--- a/strings_test.go
+++ b/strings_test.go
@@ -235,6 +235,18 @@ func TestINCRBYFLOAT(t *testing.T) {
 	}
 }
 
+// Test incrementing values for a string value
+func TestINCRBYFLOATString(t *testing.T) {
+	db := setUp()
+	n := 312.12345
+	key := "foo"
+	db.SET(key, "string value")
+	got, err := db.INCRBYFLOAT(key, n)
+	if err.Error() != "typemismatch" {
+		t.Errorf("INCRBYFLOAT(%q, %f) == %f, %v want 0, typemismatch", key, n, got, err)
+	}
+}
+
 func TestSETEXWithinExp(t *testing.T) {
 	// One second before expiry time
 	key := "mykey"


### PR DESCRIPTION
Increment the string representing a floating point number stored at key by the specified increment. If the key does not exist, it is set to 0 before performing the operation. An error is returned if one of the following conditions occur:
The key contains a value of the wrong type (not a string).
The current key content or the specified increment are not parsable as a double precision floating point number.