### PR TITLE
Allow failures for tip release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
  - 1.4.2
  - 1.5.1
  - release
+ - tip
+allow_failures:
+ - tip
 before_install:
  - go get github.com/axw/gocov/gocov
  - go get github.com/mattn/goveralls


### PR DESCRIPTION
in travis, tip fails occasionally. 
add it to allow_failures to ignore it.
